### PR TITLE
List workspaces and jwt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.6.2",
+        "js-cookie": "^3.0.5",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -14300,6 +14301,14 @@
       "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {
@@ -32569,6 +32578,11 @@
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
       "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q=="
+    },
+    "js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.6.2",
+    "js-cookie": "^3.0.5",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,9 @@
+import { React } from 'react';
 import { Route, Routes } from 'react-router-dom';
-
-import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { getReservations } from './redux/reservations/reservationsSlice';
-import { getWorkspaces } from './redux/workspaces/workspacesSlice';
+import Cookies from 'js-cookie';
+
+import { setToken, clearToken } from './redux/auth/authSlice';
 
 import Layout from './routes/Layout';
 import HomePage from './routes/HomePage';
@@ -21,13 +21,19 @@ import RemoveWorkspacePage from './routes/RemoveWorkspacePage';
 
 import ErrorPage from './routes/ErrorPage';
 
-const Root = () => {
+const App = () => {
   const dispatch = useDispatch();
+  const token = Cookies.get('token');
+  const username = Cookies.get('username');
 
-  useEffect(() => {
-    dispatch(getWorkspaces());
-    dispatch(getReservations());
-  }, [dispatch]);
+  if (token) {
+    dispatch(setToken({
+      username,
+      token,
+    }));
+  } else {
+    dispatch(clearToken());
+  }
 
   return (
     <Routes>
@@ -52,4 +58,4 @@ const Root = () => {
   );
 };
 
-export default Root;
+export default App;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,56 +1,75 @@
+import React from 'react';
 import { NavLink } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+
 import styles from '../styles/Header.module.css';
 
-const Header = () => (
-  <header className={styles.header}>
-    <p>This is header</p>
-    <nav className={styles.navigation}>
-      <ul>
-        <li className={styles.link}>
-          <NavLink to="/">
-            workspaces
-          </NavLink>
-        </li>
-        <li className={styles.link}>
-          <NavLink to="/reservations">
-            my reservations
-          </NavLink>
-        </li>
-        <li className={styles.link}>
-          <NavLink to="/new_reservation">
-            reserve
-          </NavLink>
-        </li>
-        <li className={styles.link}>
-          <NavLink to="/add_workspace">
-            add workspace
-          </NavLink>
-        </li>
-        <li className={styles.link}>
-          <NavLink to="/remove_workspace">
-            delete workspace
-          </NavLink>
-        </li>
-        {/* if the user is authenticated */}
-        <li className={styles.link}>
-          <NavLink to="/sign_out">
-            log out
-          </NavLink>
-        </li>
-        {/* if the user is not authenticated */}
-        <li className={styles.link}>
-          <NavLink to="/sign_in">
-            log in
-          </NavLink>
-        </li>
-        <li className={styles.link}>
-          <NavLink to="/sign_up">
-            sing up
-          </NavLink>
-        </li>
-      </ul>
-    </nav>
-  </header>
-);
+const Header = () => {
+  const { isAuthenticated } = useSelector((state) => state.auth);
+
+  return (
+    <header className={styles.header}>
+      <p>This is header</p>
+      <nav className={styles.navigation}>
+        <ul>
+          <li className={styles.link}>
+            <NavLink to="/">
+              workspaces
+            </NavLink>
+          </li>
+
+          { isAuthenticated && (
+            <>
+              <li className={styles.link}>
+                <NavLink to="/reservations">
+                  my reservations
+                </NavLink>
+              </li>
+              <li className={styles.link}>
+                <NavLink to="/new_reservation">
+                  reserve
+                </NavLink>
+              </li>
+              <li className={styles.link}>
+                <NavLink to="/add_workspace">
+                  add workspace
+                </NavLink>
+              </li>
+              <li className={styles.link}>
+                <NavLink to="/remove_workspace">
+                  delete workspace
+                </NavLink>
+              </li>
+            </>
+          )}
+          {
+            isAuthenticated
+              ? (
+                <li className={styles.link}>
+                  <NavLink to="/sign_out">
+                    log out
+                  </NavLink>
+                </li>
+              )
+              : (
+                <>
+                  <li className={styles.link}>
+                    <NavLink to="/sign_in">
+                      log in
+                    </NavLink>
+                  </li>
+                  <li className={styles.link}>
+                    <NavLink to="/sign_up">
+                      sing up
+                    </NavLink>
+                  </li>
+                </>
+              )
+            }
+        </ul>
+      </nav>
+    </header>
+  );
+};
 
 export default Header;

--- a/src/components/WorkspaceItem.js
+++ b/src/components/WorkspaceItem.js
@@ -7,21 +7,30 @@ import noImage from '../assets/no-image.png';
 
 const WorkspaceItem = ({ spaceId }) => {
   const { workspaces } = useSelector((store) => store.workspaces);
-  const workspace = workspaces.find((space) => space.ID === spaceId);
+  const workspace = workspaces.find((space) => space.id === spaceId);
 
+  if (workspace) {
+    return (
+      <>
+        <h3>Details about the room reserved:</h3>
+        <span>Room name:</span>
+        {' '}
+        <span>{ workspace.name }</span>
+        <div>
+          {(workspace.image_url)
+            ? <img alt={`${workspace.name}`} src={workspace.image_url} />
+            : <img alt="not provided" src={noImage} />}
+        </div>
+        <span>{ workspace.description }</span>
+      </>
+    );
+  }
   return (
-    <>
-      <h3>Details about the room reserved:</h3>
-      <span>Room name:</span>
-      {' '}
-      <span>{ workspace.name }</span>
-      <div>
-        {(workspace.image)
-          ? <img alt={`${workspace.name}`} src={workspace.image} />
-          : <img alt="not provided" src={noImage} />}
-      </div>
-      <span>{ workspace.description }</span>
-    </>
+    <p>
+      Ooops! Something went wrong.
+      <br />
+      We couldn&apos;t find information about this room.
+    </p>
   );
 };
 

--- a/src/components/Workspaces.js
+++ b/src/components/Workspaces.js
@@ -1,5 +1,3 @@
-// import { useSelector } from 'react-redux';
-// import { useState } from 'react';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
@@ -24,7 +22,7 @@ const Workspaces = () => {
       </p>
     );
   }
-  if (workspaces) {
+  if (workspaces.length > 0) {
     return (
       <div className={styles.page}>
         <h1>Workspaces go here</h1>
@@ -32,13 +30,13 @@ const Workspaces = () => {
         <ul className={styles.list}>
           {workspaces.map((space) => (
             <li
-              key={space.ID}
+              key={space.id}
               className={styles.space_card}
             >
-              <Link to={`workspaces/${space.ID}`}>
+              <Link to={`workspaces/${space.id}`}>
                 <div className={styles.image}>
-                  {(space.image)
-                    ? <img alt={`${space.name}`} src={space.image} />
+                  {(space.image_url)
+                    ? <img alt={`${space.name}`} src={space.image_url} />
                     : <img alt="not provided" src={noImage} />}
                 </div>
                 <div className={styles.space_info}>

--- a/src/redux/auth/authSlice.js
+++ b/src/redux/auth/authSlice.js
@@ -4,17 +4,20 @@ import { createSlice } from '@reduxjs/toolkit';
 const authSlice = createSlice({
   name: 'auth',
   initialState: {
+    username: null,
     token: null,
     isAuthenticated: false,
   },
   reducers: {
     // To Log in, use this reducer: setToken then redirect to home page
     setToken: (state, action) => {
-      state.token = action.payload;
+      state.username = action.payload.username;
+      state.token = action.payload.token;
       state.isAuthenticated = !!action.payload;
     },
     // To Log out, use this reducer: clearToken then redirect to login page or home page
     clearToken: (state) => {
+      state.username = null;
       state.token = null;
       state.isAuthenticated = false;
     },

--- a/src/redux/reservations/reservationsSlice.js
+++ b/src/redux/reservations/reservationsSlice.js
@@ -5,61 +5,22 @@ const RESERVATIONS_URL = 'http://127.0.0.1:3000/api/v1/reservations';
 
 export const getReservations = createAsyncThunk(
   'reservations/getReservations',
-  async (_, thunkAPI) => {
+  async (token, { rejectWithValue }) => {
     try {
-      const resp = await axios.get(RESERVATIONS_URL);
+      const resp = await axios.get(RESERVATIONS_URL, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
       return resp.data;
     } catch (error) {
-      return thunkAPI.rejectWithValue(error);
+      return rejectWithValue(error.response.data);
     }
   },
 );
 
-const ReservationsJson = [
-  {
-    ID: 1,
-    start_date: '4.12.2023',
-    end_date: '5.12.2023',
-    city: 'Redmond',
-    user_id: 4,
-    workspace_id: 1,
-  },
-  {
-    ID: 2,
-    start_date: '6.12.2023',
-    end_date: '6.12.2023',
-    city: 'Freiburg',
-    user_id: 4,
-    workspace_id: 2,
-  },
-  {
-    ID: 3,
-    start_date: '7.12.2023',
-    end_date: '8.12.2023',
-    city: 'Trinidad',
-    user_id: 4,
-    workspace_id: 3,
-  },
-  {
-    ID: 4,
-    start_date: '4.12.2023',
-    end_date: '5.12.2023',
-    city: 'Ito',
-    user_id: 3,
-    workspace_id: 3,
-  },
-  {
-    ID: 5,
-    start_date: '7.12.2023',
-    end_date: '8.12.2023',
-    city: 'Appleton',
-    user_id: 3,
-    workspace_id: 4,
-  },
-];
-
 const initialState = {
-  reservations: ReservationsJson,
+  reservations: [],
   isLoading: false,
   error: undefined,
 };

--- a/src/redux/workspaces/workspacesSlice.js
+++ b/src/redux/workspaces/workspacesSlice.js
@@ -22,8 +22,13 @@ export const getWorkspaces = createAsyncThunk(
 export const postWorkspace = createAsyncThunk(
   'workspaces/postworkspaces',
   async (newData, { rejectWithValue }) => {
+    const {data, token} = newData
     try {
-      const response = await axios.post(WORKSPACES_URL, newData);
+      const response = await axios.post(WORKSPACES_URL, data, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
       return response.data;
     } catch (error) {
       return rejectWithValue(error.response.data);

--- a/src/redux/workspaces/workspacesSlice.js
+++ b/src/redux/workspaces/workspacesSlice.js
@@ -21,12 +21,12 @@ export const getWorkspaces = createAsyncThunk(
 
 export const postWorkspace = createAsyncThunk(
   'workspaces/postworkspaces',
-  async (newData, thunkAPI) => {
+  async (newData, { rejectWithValue }) => {
     try {
       const response = await axios.post(WORKSPACES_URL, newData);
       return response.data;
     } catch (error) {
-      return thunkAPI.rejectWithValue(error);
+      return rejectWithValue(error.response.data);
     }
   },
 );

--- a/src/redux/workspaces/workspacesSlice.js
+++ b/src/redux/workspaces/workspacesSlice.js
@@ -22,7 +22,7 @@ export const getWorkspaces = createAsyncThunk(
 export const postWorkspace = createAsyncThunk(
   'workspaces/postworkspaces',
   async (newData, { rejectWithValue }) => {
-    const {data, token} = newData
+    const { data, token } = newData;
     try {
       const response = await axios.post(WORKSPACES_URL, data, {
         headers: {

--- a/src/redux/workspaces/workspacesSlice.js
+++ b/src/redux/workspaces/workspacesSlice.js
@@ -5,51 +5,22 @@ const WORKSPACES_URL = 'http://127.0.0.1:3000/api/v1/workspaces';
 
 export const getWorkspaces = createAsyncThunk(
   'workspaces/getWorkspaces',
-  async (_, thunkAPI) => {
+  async (token, { rejectWithValue }) => {
     try {
-      const resp = await axios.get(WORKSPACES_URL);
+      const resp = await axios.get(WORKSPACES_URL, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
       return resp.data;
     } catch (error) {
-      return thunkAPI.rejectWithValue(error);
+      return rejectWithValue(error.response.data);
     }
   },
 );
 
-const WorkspacesJson = [
-  {
-    ID: 1,
-    name: 'room#1',
-    image: 'https://i.pravatar.cc/300?img=1',
-    description: 'Simple room with 1 seat and 1 talbes, no equipment is provided',
-  },
-  {
-    ID: 2,
-    name: 'room#2',
-    image: 'https://i.pravatar.cc/300?img=2',
-    description: 'Simple room with 2 seats and 1 talbe, no equipment is provided',
-  },
-  {
-    ID: 3,
-    name: 'room#3',
-    image: 'https://i.pravatar.cc/300?img=3',
-    description: 'Large room with 3 seats and 2 talbes, 1 monitor for presentations',
-  },
-  {
-    ID: 4,
-    name: 'room#4',
-    image: 'https://i.pravatar.cc/300?img=4',
-    description: 'Large room with 4 seats and 2 talbes, 1 monitor for presentations',
-  },
-  {
-    ID: 5,
-    name: 'room#5',
-    image: '',
-    description: 'Large room with 5 seats and 2 talbes, 1 monitor for presentations',
-  },
-];
-
 const initialState = {
-  workspaces: WorkspacesJson,
+  workspaces: [],
   isLoading: false,
   error: undefined,
 };

--- a/src/routes/AddWorkspacePage.js
+++ b/src/routes/AddWorkspacePage.js
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { postWorkspace } from '../redux/workspaces/workspacesSlice';
 import styles from '../styles/AddWorkspacePage.module.css';
 
 const AddWorkspacePage = () => {
+  const { token } = useSelector((state) => state.auth);
   const dispatch = useDispatch();
   const [success, setSuccess] = useState(null);
   const [fail, setFail] = useState(null);
@@ -20,7 +21,11 @@ const AddWorkspacePage = () => {
     }
 
     try {
-      const resultAction = await dispatch(postWorkspace(data));
+      const sendData = {
+        data,
+        token
+      }
+      const resultAction = await dispatch(postWorkspace(sendData));
       if (resultAction.payload.success) {
         setSuccess(resultAction.payload.success);
       }

--- a/src/routes/AddWorkspacePage.js
+++ b/src/routes/AddWorkspacePage.js
@@ -23,8 +23,8 @@ const AddWorkspacePage = () => {
     try {
       const sendData = {
         data,
-        token
-      }
+        token,
+      };
       const resultAction = await dispatch(postWorkspace(sendData));
       if (resultAction.payload.success) {
         setSuccess(resultAction.payload.success);

--- a/src/routes/HomePage.js
+++ b/src/routes/HomePage.js
@@ -1,13 +1,16 @@
-import React from 'react';
-import { useSelector } from 'react-redux';
+import { React, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { getWorkspaces } from '../redux/workspaces/workspacesSlice';
 import Workspaces from '../components/Workspaces';
 
 const HomePage = () => {
-  // Use token and isAuthenticated from the Redux store
-  const { token, isAuthenticated } = useSelector((state) => state.auth);
+  const { username, token, isAuthenticated } = useSelector((state) => state.auth);
+  const dispatch = useDispatch();
 
-  // Use user info from local storage
-  const user = JSON.parse(localStorage.getItem('user'));
+  useEffect(() => {
+    dispatch(getWorkspaces(token));
+  }, [dispatch, token]);
 
   return (
     <>
@@ -18,12 +21,9 @@ const HomePage = () => {
         <div>
           <p>
             Welcome,
-            {user && user.username}
+            {' '}
+            { username }
             !
-          </p>
-          <p>
-            Your token:
-            {token}
           </p>
         </div>
       )}

--- a/src/routes/ProtectedLayout.js
+++ b/src/routes/ProtectedLayout.js
@@ -1,10 +1,22 @@
-import { Outlet } from 'react-router-dom';
+import React from 'react';
+import { Outlet, Navigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 
-const ProtectedLayout = () => (
-  <>
-    <p>This is protected layout</p>
-    <Outlet />
-  </>
-);
+// import SignInPage from './SignInPage';
+
+const ProtectedLayout = () => {
+  const { isAuthenticated } = useSelector((state) => state.auth);
+
+  return isAuthenticated ? <Outlet /> : <Navigate to="/sign_in" />;
+
+  // We can also render a custom message alongside with the SignInPage.
+  // Replace <Navigate to="/sign_in" /> with this:
+  // : (
+  //   <>
+  //     <p>You need to sign in to access this page</p>
+  //     <SignInPage />
+  //   </>
+  // );
+};
 
 export default ProtectedLayout;

--- a/src/routes/ReservationsPage.js
+++ b/src/routes/ReservationsPage.js
@@ -1,9 +1,21 @@
-import React from 'react';
-import { useSelector } from 'react-redux';
+import { React, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+import { getReservations } from '../redux/reservations/reservationsSlice';
+import { getWorkspaces } from '../redux/workspaces/workspacesSlice';
+
 import WorkspaceItem from '../components/WorkspaceItem';
 import styles from '../styles/ReservationsPage.module.css';
 
 const ReservationsPage = () => {
+  const dispatch = useDispatch();
+  const { token } = useSelector((state) => state.auth);
+
+  useEffect(() => {
+    dispatch(getReservations(token));
+    dispatch(getWorkspaces(token));
+  }, [dispatch, token]);
+
   const { reservations, isLoading, error } = useSelector((store) => store.reservations);
 
   if (isLoading) {
@@ -22,7 +34,7 @@ const ReservationsPage = () => {
     );
   }
 
-  if (reservations) {
+  if (reservations.length > 0) {
     return (
       <div className={styles.page}>
         <h1>This is ReservationsPage</h1>

--- a/src/routes/SignInPage.js
+++ b/src/routes/SignInPage.js
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import axios from 'axios';
+import Cookies from 'js-cookie';
+
 import styles from '../styles/SignInPage.module.css';
 import { setToken } from '../redux/auth/authSlice';
 
@@ -20,17 +22,11 @@ const SignInPage = () => {
       });
       if (response.status === 200) {
         // Save the token in redux store
-        dispatch(setToken(response.data.user.authentication_token));
+        dispatch(setToken(response.data));
 
-        // Guys you can use useSelector to get the
-        // token from the store and isAuthenicated
-        // from the store to use it for conditional rendering.
-
-        // Save the user in local storage
-        localStorage.setItem('user', JSON.stringify(response.data.user));
-
-        // you can use this to get the user from
-        // local storage like his id or username. I hope Everything is clear now.
+        // Save the token in Cookies
+        Cookies.set('token', response.data.token, { expires: 7, secure: true });
+        Cookies.set('username', response.data.username, { expires: 7, secure: true });
 
         setSuccessMessage(`User with username "${username}" successfully signed in. Redirecting to home page...`);
         setUsername('');

--- a/src/routes/SignOutPage.js
+++ b/src/routes/SignOutPage.js
@@ -1,7 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
+import Cookies from 'js-cookie';
+
 import { clearToken } from '../redux/auth/authSlice';
+
 import styles from '../styles/SignOutPage.module.css';
 
 const SignOutPage = () => {
@@ -10,11 +13,11 @@ const SignOutPage = () => {
   const [goodbyeMessage, setGoodbyeMessage] = useState('');
 
   useEffect(() => {
-    // Clear user from local storage
-    localStorage.removeItem('user');
-
     // Set token to null in the Redux store
     dispatch(clearToken());
+    // Remove token from Cookies
+    Cookies.remove('token', { path: '' });
+    Cookies.remove('username', { path: '' });
 
     // Show a goodbye message
     setGoodbyeMessage('Goodbye! Redirecting to the home page in some seconds...');


### PR DESCRIPTION
In this branch the following tasks were completed:

- [x] workspaces route lists all workspaces with all available information about them
- [x] reservations route lists only the reservations associated with the `current_user` with all available information about them
- [x] the user's status (logged in) persists when we close or refresh the browser (by storing the user's token and name in Cookies)
- [x] some routes are protected depending on the user's authentication status
- [x] some links in the Navbar are shown only for authenticated users
- [x] the token is retrieved from the Redux store and passed to functions to authenticate the current user