### PR TITLE
Workspace details

### DIFF
--- a/src/components/WorkspaceItem.js
+++ b/src/components/WorkspaceItem.js
@@ -1,28 +1,11 @@
 import PropTypes from 'prop-types';
-
-// VERSION 1
 import { useSelector } from 'react-redux';
-
-// VERSION 2
-// import { React, useEffect } from 'react';
-// import { useDispatch, useSelector } from 'react-redux';
-// import { getWorkspace } from '../redux/workspaces/workspacesSlice';
 
 import noImage from '../assets/no-image.png';
 
 const WorkspaceItem = ({ spaceId }) => {
-  // VERSION 1
   const { workspaces } = useSelector((store) => store.workspaces);
   const workspace = workspaces.find((space) => Number(space.id) === spaceId);
-
-  // VERSION 2
-  // const id = spaceId;
-  // const { token } = useSelector((state) => state.auth);
-  // const dispatch = useDispatch();
-  // useEffect(() => {
-  //   dispatch(getWorkspace({ token, id }));
-  // }, [dispatch, token, id]);
-  // const { workspace } = useSelector((store) => store.workspaces);
 
   if (workspace) {
     return (

--- a/src/components/WorkspaceItem.js
+++ b/src/components/WorkspaceItem.js
@@ -1,13 +1,28 @@
+import PropTypes from 'prop-types';
+
+// VERSION 1
 import { useSelector } from 'react-redux';
 
-import PropTypes from 'prop-types';
+// VERSION 2
+// import { React, useEffect } from 'react';
+// import { useDispatch, useSelector } from 'react-redux';
+// import { getWorkspace } from '../redux/workspaces/workspacesSlice';
+
 import noImage from '../assets/no-image.png';
 
-// import styles from '../styles/ReservationsPage.module.css';
-
 const WorkspaceItem = ({ spaceId }) => {
+  // VERSION 1
   const { workspaces } = useSelector((store) => store.workspaces);
-  const workspace = workspaces.find((space) => space.id === spaceId);
+  const workspace = workspaces.find((space) => Number(space.id) === spaceId);
+
+  // VERSION 2
+  // const id = spaceId;
+  // const { token } = useSelector((state) => state.auth);
+  // const dispatch = useDispatch();
+  // useEffect(() => {
+  //   dispatch(getWorkspace({ token, id }));
+  // }, [dispatch, token, id]);
+  // const { workspace } = useSelector((store) => store.workspaces);
 
   if (workspace) {
     return (

--- a/src/components/Workspaces.js
+++ b/src/components/Workspaces.js
@@ -33,7 +33,7 @@ const Workspaces = () => {
               key={space.id}
               className={styles.space_card}
             >
-              <Link to={`workspaces/${space.ID}`}>
+              <Link to={`workspaces/${space.id}`}>
                 <div className={styles.image_url}>
                   {(space.image_url)
                     ? <img alt={`${space.name}`} src={space.image_url} />

--- a/src/redux/workspaces/workspacesSlice.js
+++ b/src/redux/workspaces/workspacesSlice.js
@@ -19,6 +19,23 @@ export const getWorkspaces = createAsyncThunk(
   },
 );
 
+export const getWorkspace = createAsyncThunk(
+  'workspaces/getWorkspace',
+  async (data, { rejectWithValue }) => {
+    const { id, token } = data;
+    try {
+      const resp = await axios.get(`${WORKSPACES_URL}/${id}`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      return resp.data;
+    } catch (error) {
+      return rejectWithValue(error.response.data);
+    }
+  },
+);
+
 export const postWorkspace = createAsyncThunk(
   'workspaces/postworkspaces',
   async (newData, { rejectWithValue }) => {
@@ -37,6 +54,7 @@ export const postWorkspace = createAsyncThunk(
 );
 
 const initialState = {
+  workspace: {},
   workspaces: [],
   isLoading: false,
   error: undefined,
@@ -56,6 +74,17 @@ export const workspacesSlice = createSlice({
         state.workspaces = action.payload.workspaces;
       })
       .addCase(getWorkspaces.rejected, (state, action) => {
+        state.isLoading = false;
+        state.error = action.payload.message;
+      })
+      .addCase(getWorkspace.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(getWorkspace.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.workspace = action.payload.workspace;
+      })
+      .addCase(getWorkspace.rejected, (state, action) => {
         state.isLoading = false;
         state.error = action.payload.message;
       });

--- a/src/routes/ReservationsPage.js
+++ b/src/routes/ReservationsPage.js
@@ -41,7 +41,7 @@ const ReservationsPage = () => {
         <ul className={styles.list}>
           {reservations.map((reservation, index) => (
             <li
-              key={reservation.ID}
+              key={reservation.id}
               className={styles.reservation_card}
             >
               <h2>

--- a/src/routes/WorkspaceDetailsPage.js
+++ b/src/routes/WorkspaceDetailsPage.js
@@ -1,14 +1,8 @@
 import { useParams } from 'react-router-dom';
 
-// VERSION 1
-// import { useSelector } from 'react-redux';
-// END
-
-// VERSION 2
 import { React, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { getWorkspace } from '../redux/workspaces/workspacesSlice';
-// END
 
 import styles from '../styles/WorkspaceDetails.module.css';
 import noImage from '../assets/no-image.png';
@@ -16,26 +10,12 @@ import noImage from '../assets/no-image.png';
 const WorkspaceDetailsPage = () => {
   const dispatch = useDispatch();
   const { id } = useParams();
-
-  // VERSION 1
-  // const { token } = useSelector((state) => state.auth);
-
-  // useEffect(() => {
-  //   dispatch(getWorkspaces(token));
-  // }, [dispatch, token]);
-
-  // const { workspaces, isLoading, error } = useSelector((store) => store.workspaces);
-  // const workspace = workspaces.find((space) => String(space.id) === id);
-  // END
-
-  // VERSION 2
   const { token } = useSelector((state) => state.auth);
   const { workspace, isLoading, error } = useSelector((store) => store.workspaces);
 
   useEffect(() => {
     dispatch(getWorkspace({ token, id }));
   }, [dispatch, token, id]);
-  // END
 
   if (isLoading) {
     return (

--- a/src/routes/WorkspaceDetailsPage.js
+++ b/src/routes/WorkspaceDetailsPage.js
@@ -1,9 +1,74 @@
-import styles from '../styles/WorkspaceDetails.module.css';
+import { useParams } from 'react-router-dom';
 
-const WorkspaceDetailsPage = () => (
-  <div className={styles.page}>
-    <p>This is WorkspaceDetailsPage</p>
-  </div>
-);
+// VERSION 1
+// import { useSelector } from 'react-redux';
+// END
+
+// VERSION 2
+import { React, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { getWorkspace } from '../redux/workspaces/workspacesSlice';
+// END
+
+import styles from '../styles/WorkspaceDetails.module.css';
+import noImage from '../assets/no-image.png';
+
+const WorkspaceDetailsPage = () => {
+  const dispatch = useDispatch();
+  const { id } = useParams();
+
+  // VERSION 1
+  // const { token } = useSelector((state) => state.auth);
+
+  // useEffect(() => {
+  //   dispatch(getWorkspaces(token));
+  // }, [dispatch, token]);
+
+  // const { workspaces, isLoading, error } = useSelector((store) => store.workspaces);
+  // const workspace = workspaces.find((space) => String(space.id) === id);
+  // END
+
+  // VERSION 2
+  const { token } = useSelector((state) => state.auth);
+  const { workspace, isLoading, error } = useSelector((store) => store.workspaces);
+
+  useEffect(() => {
+    dispatch(getWorkspace({ token, id }));
+  }, [dispatch, token, id]);
+  // END
+
+  if (isLoading) {
+    return (
+      <div>Loading......</div>
+    );
+  }
+  if (error) {
+    return (
+      <p>
+        Something went wrong!
+        <br />
+        { error }
+      </p>
+    );
+  }
+  if (workspace.name) {
+    return (
+      <>
+        <div className={styles.page}>
+          <p>This is WorkspaceDetailsPage</p>
+          {(workspace.image_url)
+            ? <img alt={`${workspace.name}`} src={workspace.image_url} />
+            : <img alt="not provided" src={noImage} />}
+          <div className={workspace.workspace_info}>
+            <h2 className={workspace.name}>{workspace.name}</h2>
+            <p className={workspace.description}>{workspace.description}</p>
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  return <p>We couldn&apos;t find details about this room.</p>;
+};
 
 export default WorkspaceDetailsPage;


### PR DESCRIPTION
## This PR should be reviewed after [PR 25](https://github.com/badger-99/workspace-reservation-back-end/pull/25)

There are 2 versions for loading a single workspace (for workspace/:id route):
1. Work with the data that  was retrieved by #index action and filter it to get the single item (search is performed on the client side)
2. Make a separate request to #show action and retrieve a single record from db (search is performed on the server side)


I included both versions but I decided to go with the 2nd approach because:

- it is possible to have >100 workspaces and it will take much time to load them all to render one single workspace (consider the situation when the user is on workspace/1 page and refreshes the page, the app will need to load all >100 workspaces to displace 1 single workspace)
- when the number of workspaces is big, the filtering process might require more resources from the client (better performance of their machine), so the users using mobile/old or weak machines might face problems.

<hr>

There are also 2 versions for attaching workspace info to the reservation:
1. Work with the data that  was retrieved by #index action and filter it to get the single item (search is performed on the client side)
2. Make a separate request to #show action and retrieve a single record from db (search is performed on the server side)

I included both versions but I decided to go with the 1st approach because:

- all reservations appear on 1 page so with the 2nd approach we would need to make 10 requests for 10 reservations. Doing one request (load all workspaces associated with reservations at once) and working with the retrieved array is better. It will make sure that users with slow internet have a better experience;
- the client side will likely be ok performing the search because we show only reservations per user (and it's unlikely that 1 user will have 100 reservations).

### I will delete the comments (unused versions) after the review. I left them to be able to quickly switch between them during decision making.