### PR TITLE
Remove workspace

### DIFF
--- a/src/redux/workspaces/workspacesSlice.js
+++ b/src/redux/workspaces/workspacesSlice.js
@@ -121,7 +121,7 @@ export const workspacesSlice = createSlice({
         state.isLoading = false;
         state.error = action.payload.message;
       })
-    .addCase(postWorkspace.pending, (state) => {
+      .addCase(postWorkspace.pending, (state) => {
         state.isPosting = true;
       })
       .addCase(postWorkspace.fulfilled, (state) => {
@@ -140,7 +140,7 @@ export const workspacesSlice = createSlice({
       .addCase(deleteWorkspace.rejected, (state, action) => {
         state.isDeleting = false;
         state.deleteFail = action.payload.message;
-    });
+      });
   },
 });
 

--- a/src/redux/workspaces/workspacesSlice.js
+++ b/src/redux/workspaces/workspacesSlice.js
@@ -20,7 +20,7 @@ export const getWorkspaces = createAsyncThunk(
 );
 
 export const postWorkspace = createAsyncThunk(
-  'workspaces/postworkspaces',
+  'workspaces/postWorkspaces',
   async (newData, { rejectWithValue }) => {
     const { data, token } = newData;
     try {
@@ -29,6 +29,26 @@ export const postWorkspace = createAsyncThunk(
           Authorization: `Bearer ${token}`,
         },
       });
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response.data);
+    }
+  },
+);
+
+export const deleteWorkspace = createAsyncThunk(
+  'workspaces/deleteWorkspaces',
+  async (deleteData, { rejectWithValue }) => {
+    const { id, token } = deleteData;
+    try {
+      const response = await axios.delete(
+        `http://127.0.0.1:3000/api/v1/workspaces/${id}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        },
+      );
       return response.data;
     } catch (error) {
       return rejectWithValue(error.response.data);

--- a/src/redux/workspaces/workspacesSlice.js
+++ b/src/redux/workspaces/workspacesSlice.js
@@ -60,12 +60,25 @@ const initialState = {
   workspaces: [],
   isLoading: false,
   error: undefined,
+  // post states
+  isPosting: false,
+  postFail: undefined,
+  // delete states
+  isDeleting: false,
+  deleteFail: undefined,
 };
 
 export const workspacesSlice = createSlice({
   name: 'workspaces',
   initialState,
-  reducers: {},
+  reducers: {
+    resetPostFail: (state) => {
+      state.postFail = undefined;
+    },
+    resetDeleteFail: (state) => {
+      state.deleteFail = undefined;
+    },
+  },
   extraReducers(builder) {
     builder
       .addCase(getWorkspaces.pending, (state) => {
@@ -78,8 +91,29 @@ export const workspacesSlice = createSlice({
       .addCase(getWorkspaces.rejected, (state, action) => {
         state.isLoading = false;
         state.error = action.payload.message;
+      })
+      .addCase(postWorkspace.pending, (state) => {
+        state.isPosting = true;
+      })
+      .addCase(postWorkspace.fulfilled, (state) => {
+        state.isPosting = false;
+      })
+      .addCase(postWorkspace.rejected, (state, action) => {
+        state.isPosting = false;
+        state.postFail = action.payload.message;
+      })
+      .addCase(deleteWorkspace.pending, (state) => {
+        state.isDeleting = true;
+      })
+      .addCase(deleteWorkspace.fulfilled, (state) => {
+        state.isDeleting = false;
+      })
+      .addCase(deleteWorkspace.rejected, (state, action) => {
+        state.isDeleting = false;
+        state.deleteFail = action.payload.message;
       });
   },
 });
 
+export const { resetPostFail, resetDeleteFail } = workspacesSlice.actions;
 export default workspacesSlice.reducer;

--- a/src/routes/AddWorkspacePage.js
+++ b/src/routes/AddWorkspacePage.js
@@ -1,10 +1,13 @@
 import { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { postWorkspace } from '../redux/workspaces/workspacesSlice';
+import { postWorkspace, resetPostFail } from '../redux/workspaces/workspacesSlice';
 import styles from '../styles/AddWorkspacePage.module.css';
 
 const AddWorkspacePage = () => {
   const { token } = useSelector((state) => state.auth);
+  const { isPosting, postFail } = useSelector(
+    (store) => store.workspaces,
+  );
   const dispatch = useDispatch();
   const [success, setSuccess] = useState(null);
   const [fail, setFail] = useState(null);
@@ -45,18 +48,23 @@ const AddWorkspacePage = () => {
     const timer = setTimeout(() => {
       setSuccess(null);
       setFail(null);
+      if (postFail) {
+        dispatch(resetPostFail);
+      }
     }, 3000);
 
     if (success) {
       resetform();
     }
     return () => clearTimeout(timer);
-  }, [success, fail]);
+  }, [success, fail, dispatch, postFail]);
 
   return (
     <div className={styles.page}>
       {success && <p>{success}</p>}
       {fail && <p>{fail}</p>}
+      {isPosting && <p>Creating Workspace...</p>}
+      {postFail && <p>{ postFail }</p>}
       <p>Create New Workspace</p>
       <form ref={formRef} onSubmit={(e) => handleSubmit(e)}>
         <label htmlFor="name">
@@ -67,7 +75,13 @@ const AddWorkspacePage = () => {
         <br />
         <label htmlFor="description">
           Description
-          <textarea name="description" id="description" rows="4" cols="50" required />
+          <textarea
+            name="description"
+            id="description"
+            rows="4"
+            cols="50"
+            required
+          />
         </label>
         <br />
         <br />

--- a/src/routes/AddWorkspacePage.js
+++ b/src/routes/AddWorkspacePage.js
@@ -25,12 +25,12 @@ const AddWorkspacePage = () => {
         data,
         token,
       };
-      const resultAction = await dispatch(postWorkspace(sendData));
-      if (resultAction.payload.success) {
-        setSuccess(resultAction.payload.success);
+      const actionResult = await dispatch(postWorkspace(sendData));
+      if (actionResult.payload.success) {
+        setSuccess(actionResult.payload.success);
       }
-      if (resultAction.payload.error) {
-        setFail(resultAction.payload.error);
+      if (actionResult.payload.error) {
+        setFail(actionResult.payload.error);
       }
     } catch (error) {
       setFail(error);

--- a/src/routes/RemoveWorkspacePage.js
+++ b/src/routes/RemoveWorkspacePage.js
@@ -1,9 +1,58 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { deleteWorkspace, getWorkspaces } from '../redux/workspaces/workspacesSlice';
 import styles from '../styles/RemoveWorkspacePage.module.css';
 
-const RemoveWorkspacePage = () => (
-  <div className={styles.page}>
-    <p>This is RemoveWorkspacePage</p>
-  </div>
-);
+const RemoveWorkspacePage = () => {
+  const { token } = useSelector((state) => state.auth);
+  const { workspaces, isLoading, error } = useSelector(
+    (store) => store.workspaces,
+  );
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(getWorkspaces(token));
+  }, [dispatch, token]);
+
+  const handleDelete = async (id) => {
+    console.log(id);
+  };
+
+
+  if (isLoading) {
+    return <div>Loading......</div>;
+  }
+  if (error) {
+    return (
+      <p>
+        Something went wrong!
+        <br />
+        {error}
+      </p>
+    );
+  }
+
+  return (
+    <div className={styles.page}>
+      <p>List workspaces with a delete button</p>
+      {success && <p>{success}</p>}
+      {fail && <p>{fail}</p>}
+      <ul>
+        {workspaces.map((space) => (
+          <li key={space.id}>
+            <p>{space.name}</p>
+            <img alt={`${space.name}`} src={space.image_url} />
+            <button
+              type="button"
+              onClick={() => {
+                handleDelete(space.id);
+              }}
+            >
+              delete
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
 
 export default RemoveWorkspacePage;

--- a/src/routes/RemoveWorkspacePage.js
+++ b/src/routes/RemoveWorkspacePage.js
@@ -63,7 +63,7 @@ const RemoveWorkspacePage = () => {
   return (
     <div className={styles.page}>
       <p>List workspaces with a delete button</p>
-      {isDeleting && <p>Deleting Workspace...</p>}
+      {isDeleting && <p>Deleting Workspace....</p>}
       {success && <p>{success}</p>}
       {fail && <p>{fail}</p>}
       {deleteFail && <p>{deleteFail}</p>}

--- a/src/routes/RemoveWorkspacePage.js
+++ b/src/routes/RemoveWorkspacePage.js
@@ -10,11 +10,12 @@ const RemoveWorkspacePage = () => {
   );
   const dispatch = useDispatch();
   const [success, setSuccess] = useState(null);
+  const [isSuccess, setIsSuccess] = useState(false);
   const [fail, setFail] = useState(null);
 
   useEffect(() => {
     dispatch(getWorkspaces(token));
-  }, [dispatch, token]);
+  }, [dispatch, token, isSuccess]);
 
   const handleDelete = async (id) => {
     console.log(id);
@@ -24,6 +25,7 @@ const RemoveWorkspacePage = () => {
     };
     const actionResult = await dispatch(deleteWorkspace(sendData));
     if (actionResult.payload) {
+      setIsSuccess(!isSuccess);
       setSuccess(actionResult.payload.success);
       console.log(actionResult.payload);
     }
@@ -36,7 +38,7 @@ const RemoveWorkspacePage = () => {
     const timer = setTimeout(() => {
       setSuccess(null);
       setFail(null);
-    }, 3000);
+    }, 4000);
 
     return () => clearTimeout(timer);
   }, [success, fail]);

--- a/src/routes/RemoveWorkspacePage.js
+++ b/src/routes/RemoveWorkspacePage.js
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { deleteWorkspace, getWorkspaces } from '../redux/workspaces/workspacesSlice';
 import styles from '../styles/RemoveWorkspacePage.module.css';
@@ -8,14 +9,37 @@ const RemoveWorkspacePage = () => {
     (store) => store.workspaces,
   );
   const dispatch = useDispatch();
+  const [success, setSuccess] = useState(null);
+  const [fail, setFail] = useState(null);
+
   useEffect(() => {
     dispatch(getWorkspaces(token));
   }, [dispatch, token]);
 
   const handleDelete = async (id) => {
     console.log(id);
+    const sendData = {
+      id,
+      token,
+    };
+    const actionResult = await dispatch(deleteWorkspace(sendData));
+    if (actionResult.payload) {
+      setSuccess(actionResult.payload.success);
+      console.log(actionResult.payload);
+    }
+    if (actionResult.payload.error) {
+      setFail(actionResult.payload.error);
+    }
   };
 
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSuccess(null);
+      setFail(null);
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, [success, fail]);
 
   if (isLoading) {
     return <div>Loading......</div>;

--- a/src/routes/RemoveWorkspacePage.js
+++ b/src/routes/RemoveWorkspacePage.js
@@ -1,11 +1,14 @@
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { deleteWorkspace, getWorkspaces } from '../redux/workspaces/workspacesSlice';
+import { deleteWorkspace, getWorkspaces, resetDeleteFail } from '../redux/workspaces/workspacesSlice';
 import styles from '../styles/RemoveWorkspacePage.module.css';
+// import RemoveWorkspace from '../components/RemoveWorkspace';
 
 const RemoveWorkspacePage = () => {
   const { token } = useSelector((state) => state.auth);
-  const { workspaces, isLoading, error } = useSelector(
+  const {
+    workspaces, isLoading, error, isDeleting, deleteFail,
+  } = useSelector(
     (store) => store.workspaces,
   );
   const dispatch = useDispatch();
@@ -18,7 +21,6 @@ const RemoveWorkspacePage = () => {
   }, [dispatch, token, isSuccess]);
 
   const handleDelete = async (id) => {
-    console.log(id);
     const sendData = {
       id,
       token,
@@ -27,7 +29,6 @@ const RemoveWorkspacePage = () => {
     if (actionResult.payload) {
       setIsSuccess(!isSuccess);
       setSuccess(actionResult.payload.success);
-      console.log(actionResult.payload);
     }
     if (actionResult.payload.error) {
       setFail(actionResult.payload.error);
@@ -38,10 +39,13 @@ const RemoveWorkspacePage = () => {
     const timer = setTimeout(() => {
       setSuccess(null);
       setFail(null);
+      if (deleteFail) {
+        dispatch(resetDeleteFail);
+      }
     }, 4000);
 
     return () => clearTimeout(timer);
-  }, [success, fail]);
+  }, [success, fail, dispatch, deleteFail]);
 
   if (isLoading) {
     return <div>Loading......</div>;
@@ -59,8 +63,10 @@ const RemoveWorkspacePage = () => {
   return (
     <div className={styles.page}>
       <p>List workspaces with a delete button</p>
+      {isDeleting && <p>Deleting Workspace...</p>}
       {success && <p>{success}</p>}
       {fail && <p>{fail}</p>}
+      {deleteFail && <p>{deleteFail}</p>}
       <ul>
         {workspaces.map((space) => (
           <li key={space.id}>


### PR DESCRIPTION
In this PR I introduce the Delete Workspace page where a user sees a list of all the workspaces and chooses which ones to delete. On loading the page, it sends a request to the back-end for a list of all the workspaces so that the user gets the most updated list in case they navigate to the delete workspace page right after creating a workspace.

A second included feature is the rendering of pending and rejected requests in the New Workspace form (Fulfilled responses had been implemented in a previous PR), and rendering pending, fulfilled, and rejected responses in the Delete Workspace form. 