### PR TITLE
Remove New Reservations page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ import SignOutPage from './routes/SignOutPage';
 import SignUpPage from './routes/SignUpPage';
 
 import ProtectedLayout from './routes/ProtectedLayout';
-import NewReservationPage from './routes/NewReservationPage';
+// import NewReservationPage from './routes/NewReservationPage';
 import ReservationsPage from './routes/ReservationsPage';
 import AddWorkspacePage from './routes/AddWorkspacePage';
 import RemoveWorkspacePage from './routes/RemoveWorkspacePage';
@@ -42,7 +42,10 @@ const App = () => {
         <Route path="workspaces/:id" element={<WorkspaceDetailsPage />} />
 
         <Route path="/" element={<ProtectedLayout />}>
-          <Route path="new_reservation" element={<NewReservationPage />} />
+          {/* New Reservations is Extra Route with Redundant functionality and
+          it isn't needed as this functionality is already achieved when
+          we click on a specific workspace to reserve it. */}
+          {/* <Route path="new_reservation" element={<NewReservationPage />} /> */}
           <Route path="reservations" element={<ReservationsPage />} />
           <Route path="add_workspace" element={<AddWorkspacePage />} />
           <Route path="remove_workspace" element={<RemoveWorkspacePage />} />

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -23,9 +23,11 @@ const Header = () => {
             <li className="hover:bg-green-500 p-4 rounded-lg">
               <NavLink className="text-lg" to="/reservations">my reservations</NavLink>
             </li>
-            <li className="hover:bg-green-500 p-4 rounded-lg">
+            {/* The Reserve Option is not needed and since commented out. */}
+
+            {/* <li className="hover:bg-green-500 p-4 rounded-lg">
               <NavLink className="text-lg" to="/new_reservation">reserve</NavLink>
-            </li>
+            </li> */}
             <li className="hover:bg-green-500 p-4 rounded-lg">
               <NavLink className="text-lg" to="/add_workspace">add workspace</NavLink>
             </li>


### PR DESCRIPTION
- There Exists Two Flows to Reserve A Workspace and WE actually Need Only One way to reserve the workspace.
- I removed The Reserve Option in the Header that allows us to reserve New workspace.
- I removed the New Reservation Page.
- Now, Users can reserve the Space by clicking on the workspace they want to reserve and There will be a description and reservation form to fill to reserve the Workspace.